### PR TITLE
External Dependency Retries

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -44,6 +44,12 @@ verifier:
 
 
 suites:
+  - name: latest
+    provisioner:
+      playbook: tests/vagrant/latest.yml
+    verifier:
+      command: PLAYBOOK=tests/vagrant/latest.yml bundle exec rspec -c -f d -I serverspec
+
   - name: os-engine
     provisioner:
       playbook: tests/cloud/os-engine.yml
@@ -75,7 +81,7 @@ suites:
     verifier:
       command: PLAYBOOK=tests/cloud/storage-aufs.yml bundle exec rspec -c  -I serverspec
 
-  # The suite block_device_mappings overwrite the platform configuration. To allow for the /dev/sda1 
+  # The suite block_device_mappings overwrite the platform configuration. To allow for the /dev/sda1
   # volume to be deleted under, it must be configured under suites. This forces the creation of an
   # additional suite when using the ec2 driver
   - name: storage-btrfs-centos

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,12 @@ verifier:
   name: shell
 
 suites:
+  - name: latest
+    provisioner:
+      playbook: tests/vagrant/latest.yml
+    verifier:
+      command: PLAYBOOK=tests/vagrant/latest.yml bundle exec rspec -c -f d -I serverspec
+
   - name: os-engine
     provisioner:
       playbook: tests/vagrant/os-engine.yml

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ Role Variables
 Enables or disables specific components of the Docker Role.
 
 |             Variable Name            | Default |                                                                  Description                                                                 |
-|:------------------------------------:|--------:|:--------------------------------------------------------------------------------------------------------------------------------------------:|
-|          `docker_manage_py`          |  `true` |                      Installs docker-py, either from repo or pip. **Note:** This is required for credential management.                      |
+|:------------------------------------:|:-------:|:--------------------------------------------------------------------------------------------------------------------------------------------:|
+|      `external_dependency_delay`     |   `20`  |                               The time in seconds between external dependency retries. (repos, keyservers, etc)                              |
+|     `external_dependency_retries`    |   `6`   |                                      The number of retries to attempt accessing an external dependency.                                      |
+|          `docker_manage_py`          |  `true` |       Installs docker-py, either from repo or pip. **Note:** This is required for container, credential, image and network management.       |
 |      `docker_manage_engine_repo`     |  `true` |                  Manages the Docker repo. Provides support for both the Open Source and Commercially Supported Repositories.                 |
 |    `docker_manage_engine_storage`    | `false` | If true, the storage driver for the Docker Engine will be managed by the role. No storage-driver or storage-opt should be supplied manually. |
 |     `docker_manage_engine_users`     |  `true` |                              Creates and manages a docker group that is granted rights to interact with Docker.                              |

--- a/Rakefile
+++ b/Rakefile
@@ -50,6 +50,11 @@ namespace :integration do
     config = Kitchen::Config.new(loader: @loader, log_level: @log_level)
     concurrency = (ENV['concurrency'] || '1').to_i
 
+    desc 'Execute the Vagrant test suite for the latest version of Docker Engine and docker-py.'
+    task :latest do
+      task_runner(config, 'latest', 'test', concurrency)
+    end
+
     desc 'Execute the Vagrant test suite for the Open Source Docker Engine.'
     task :'os-engine' do
       task_runner(config, 'os-engine', 'test', concurrency)
@@ -105,6 +110,11 @@ namespace :integration do
       @loader = Kitchen::Loader::YAML.new(local_config: '.kitchen.cloud.yml')
       config = Kitchen::Config.new(loader: @loader, log_level: @log_level)
       concurrency = (ENV['concurrency'] || '8').to_i
+
+      desc 'Execute the Cloud test suite for the latest version of Docker Engine and docker-py.'
+      task :latest do
+        task_runner(config, 'latest', 'test', concurrency)
+      end
 
       desc 'Execute the Cloud test suite for the Open Source Docker Engine.'
       task :'os-engine' do

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,9 +5,18 @@
 # Execution Controls
 # ------------------------------
 #
-# docker_manage_containers:
+# external_dependency_delay: The time in seconds between external dependency retries.
+#   An external dependency is any link, package, cache etc that is to be fetched or
+#   updated.
 #
-# docker_manage_images:
+# external_dependency_retries: The number of retries to attempt to query an external
+#   dependnecy.
+#
+# docker_manage_containers: If true, the role will attempt to manage the containers
+#   on the host via the docker_containers array.
+#
+# docker_manage_images: If true, the role will manage images on the host via the
+#   docker_images array.
 #
 # docker_manage_engine_repo: If managed, it will use the public repos for
 #   both the Open Source and Commercial Packages. Set to false if using an
@@ -17,9 +26,11 @@
 #   block are defined. This will auto-configure the associated storage config
 #   (mainly for lvm).
 #
-# docker_manage_engine_users:
+# docker_manage_engine_users: If true, the role will attempt to manage the users
+#   who are a member of the docker group, allowing access to the docker engine.
 #
-# docker_engine_networks_managed:
+# docker_engine_networks_managed: If true, the role will attempt to manage the
+#   container networks on the host via the docker_networks array.
 #
 # docker_manage_py: If managed, this will install the docker-py libraries
 #   in a manner of your choosing. docker-py is required for credential
@@ -29,7 +40,8 @@
 #   registry authentication for specific users (defaults to current executing
 #   user).
 
-
+external_dependency_delay: 20
+external_dependency_retries: 6
 docker_manage_containers: True
 docker_manage_images: True
 docker_manage_engine_repo: True
@@ -38,8 +50,6 @@ docker_manage_engine_users: True
 docker_manage_engine_networks: True
 docker_manage_py: True
 docker_manage_registry_credentials: True
-pkg_retries: 5
-pkg_delay: 20
 
 
 # ------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,8 @@ docker_manage_engine_users: True
 docker_manage_engine_networks: True
 docker_manage_py: True
 docker_manage_registry_credentials: True
-
+pkg_retries: 5
+pkg_delay: 20
 
 
 # ------------------------------

--- a/tasks/container_execution.yml
+++ b/tasks/container_execution.yml
@@ -1,4 +1,7 @@
 ---
+# External_dependency management is NOT handled in this section as container
+# execution covers a very broad spectrum. Images should be pulled through
+# container_images before running in this section.
 
 - name: Manage Container Exeuction
   docker_container:

--- a/tasks/container_images.yml
+++ b/tasks/container_images.yml
@@ -1,4 +1,6 @@
 ---
+# External dependency management IS done here as this is mostly used
+# for pulling and not building images.
 
 - name: Manage Container Images
   docker_image:
@@ -34,4 +36,8 @@
     tls_client_key: '{{ item.tls_client_key|default(omit) }}'
     tls_hostname: '{{ item.tls_hostname|default(omit) }}'
     tls_verify: '{{ item.tls_verify|default(omit) }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   with_items: '{{ docker_images|default([]) }}'

--- a/tasks/engine/debian/engine_install.yml
+++ b/tasks/engine/debian/engine_install.yml
@@ -2,10 +2,18 @@
 
 - name: Install Docker Engine
   package: name='docker-engine={{ docker_engine_version }}*' state=present
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   when: (docker_engine_version is defined) and (docker_engine_version is not none)
 
 - name: Install Latest Docker Engine
   package: name='docker-engine' state=latest
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   when: (docker_engine_version is not defined) or (docker_engine_version is none)
 
 # Upstart (Ubuntu 14.04)

--- a/tasks/engine/debian/engine_install.yml
+++ b/tasks/engine/debian/engine_install.yml
@@ -2,18 +2,18 @@
 
 - name: Install Docker Engine
   package: name='docker-engine={{ docker_engine_version }}*' state=present
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   when: (docker_engine_version is defined) and (docker_engine_version is not none)
 
 - name: Install Latest Docker Engine
   package: name='docker-engine' state=latest
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   when: (docker_engine_version is not defined) or (docker_engine_version is none)
 
 # Upstart (Ubuntu 14.04)

--- a/tasks/engine/debian/repo.yml
+++ b/tasks/engine/debian/repo.yml
@@ -14,10 +14,18 @@
 
 - name: Update Apt Cache
   apt: update_cache=yes
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   when: (prereq_ath.rc != 0) or (prereq_cc.rc != 0)
 
 - name: Install Repo prereqs
   apt: name='{{ item }}'
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   with_items:
     - apt-transport-https
     - ca-certificates
@@ -27,12 +35,20 @@
   apt_key:
     keyserver: '{{ docker_engine_repo_gpg_key_server }}'
     id: '{{ docker_engine_repo_cs_gpg_key }}'
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   when: docker_engine_commercial_support|bool == true
 
 - name: Add Docker Open Source Repo GPG key
   apt_key:
     keyserver: '{{ docker_engine_repo_gpg_key_server }}'
     id: '{{ docker_engine_repo_os_gpg_key }}'
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   when: not docker_engine_commercial_support|bool == true
 
 - name: Add Docker Repo
@@ -46,4 +62,8 @@
 
 - name: Update Cache to Add Docker Repo
   apt: update_cache=yes
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   when: update_apt_cache.changed

--- a/tasks/engine/debian/repo.yml
+++ b/tasks/engine/debian/repo.yml
@@ -14,18 +14,18 @@
 
 - name: Update Apt Cache
   apt: update_cache=yes
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   when: (prereq_ath.rc != 0) or (prereq_cc.rc != 0)
 
 - name: Install Repo prereqs
   apt: name='{{ item }}'
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   with_items:
     - apt-transport-https
     - ca-certificates
@@ -35,20 +35,20 @@
   apt_key:
     keyserver: '{{ docker_engine_repo_gpg_key_server }}'
     id: '{{ docker_engine_repo_cs_gpg_key }}'
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   when: docker_engine_commercial_support|bool == true
 
 - name: Add Docker Open Source Repo GPG key
   apt_key:
     keyserver: '{{ docker_engine_repo_gpg_key_server }}'
     id: '{{ docker_engine_repo_os_gpg_key }}'
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   when: not docker_engine_commercial_support|bool == true
 
 - name: Add Docker Repo
@@ -62,8 +62,8 @@
 
 - name: Update Cache to Add Docker Repo
   apt: update_cache=yes
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   when: update_apt_cache.changed

--- a/tasks/engine/redhat/engine_install.yml
+++ b/tasks/engine/redhat/engine_install.yml
@@ -2,10 +2,18 @@
 
 - name: Install Docker Engine
   package: name='docker-engine-{{ docker_engine_version }}*' state=present
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   when: (docker_engine_version is defined) and (docker_engine_version is not none)
 
 - name: Install Latest Docker Engine
   package: name='docker-engine' state=latest
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   when: (docker_engine_version is not defined) or (docker_engine_version is none)
 
 - name: Create Docker Systemd DropIn Directory

--- a/tasks/engine/redhat/engine_install.yml
+++ b/tasks/engine/redhat/engine_install.yml
@@ -2,18 +2,18 @@
 
 - name: Install Docker Engine
   package: name='docker-engine-{{ docker_engine_version }}*' state=present
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   when: (docker_engine_version is defined) and (docker_engine_version is not none)
 
 - name: Install Latest Docker Engine
   package: name='docker-engine' state=latest
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   when: (docker_engine_version is not defined) or (docker_engine_version is none)
 
 - name: Create Docker Systemd DropIn Directory

--- a/tasks/py/pip.yml
+++ b/tasks/py/pip.yml
@@ -11,10 +11,10 @@
 
 - name: Install pip
   easy_install: name=pip state=present
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   when: (_pip_installed.rc != 0)
 
 - name: Check if pip is Up to Date
@@ -26,24 +26,24 @@
 
 - name: Upgrade pip
   pip: name=pip state=latest extra_args='{{ docker_py_pip_extra_args|default(omit) }}'
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   when: ((_pip_outdated.rc | default('1')) == 0) and (docker_py_pip_upgrade|bool == true)
 
 # This is a workaround for a known issue when installing certain packages
 # on debian based distros: https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1306991
 - name: Install docker-py Prereqs
   pip:
-    name: name: 'requests>=2.3.0'
+    name: 'requests>=2.3.0'
     state: present
     umask: '0022'
     extra_args: '{{ docker_py_pip_extra_args|default(omit) }}'
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   when: _pip_installed.rc != 0
 
 - name: pip Install docker-py
@@ -52,10 +52,10 @@
     state: present
     umask: '0022'
     extra_args: '{{ docker_py_pip_extra_args|default(omit) }}'
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   when: (docker_py_version is defined) and (docker_py_version is not none)
 
 - name: pip Install or Upgrade docker-py
@@ -64,8 +64,8 @@
     state: latest
     umask: '0022'
     extra_args: '{{ docker_py_pip_extra_args|default(omit) }}'
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   when: (docker_py_version is not defined) or (docker_py_version is none)

--- a/tasks/py/pip.yml
+++ b/tasks/py/pip.yml
@@ -11,6 +11,10 @@
 
 - name: Install pip
   easy_install: name=pip state=present
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   when: (_pip_installed.rc != 0)
 
 - name: Check if pip is Up to Date
@@ -22,30 +26,46 @@
 
 - name: Upgrade pip
   pip: name=pip state=latest extra_args='{{ docker_py_pip_extra_args|default(omit) }}'
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   when: ((_pip_outdated.rc | default('1')) == 0) and (docker_py_pip_upgrade|bool == true)
 
 # This is a workaround for a known issue when installing certain packages
 # on debian based distros: https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1306991
 - name: Install docker-py Prereqs
-  pip: 
-    name: 'requests>=2.3.0'
-    state: present 
-    umask: '0022' 
+  pip:
+    name: name: 'requests>=2.3.0'
+    state: present
+    umask: '0022'
     extra_args: '{{ docker_py_pip_extra_args|default(omit) }}'
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   when: _pip_installed.rc != 0
 
 - name: pip Install docker-py
-  pip: 
-    name: "'docker-py=={{ docker_py_version }}'" 
-    state: present 
-    umask: '0022' 
+  pip:
+    name: "'docker-py=={{ docker_py_version }}'"
+    state: present
+    umask: '0022'
     extra_args: '{{ docker_py_pip_extra_args|default(omit) }}'
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   when: (docker_py_version is defined) and (docker_py_version is not none)
 
 - name: pip Install or Upgrade docker-py
-  pip: 
-    name: docker-py 
-    state: latest 
-    umask: '0022' 
+  pip:
+    name: docker-py
+    state: latest
+    umask: '0022'
     extra_args: '{{ docker_py_pip_extra_args|default(omit) }}'
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   when: (docker_py_version is not defined) or (docker_py_version is none)

--- a/tasks/py/pkg.yml
+++ b/tasks/py/pkg.yml
@@ -2,3 +2,7 @@
 
 - name: Install docker-py package
   package: name='{{ _docker_py_pkg[ansible_os_family|lower] }}' state=present
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'

--- a/tasks/py/pkg.yml
+++ b/tasks/py/pkg.yml
@@ -2,7 +2,7 @@
 
 - name: Install docker-py package
   package: name='{{ _docker_py_pkg[ansible_os_family|lower] }}' state=present
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'

--- a/tasks/registry_credentials.yml
+++ b/tasks/registry_credentials.yml
@@ -27,4 +27,8 @@
     tls_verify: '{{ item.tls_verify|default(omit) }}'
     url: '{{ item.url|default(omit) }}'
     username: '{{ item.username }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   with_items: '{{ docker_registry_credentials|default([]) }}'

--- a/tasks/storage/main.yml
+++ b/tasks/storage/main.yml
@@ -13,9 +13,12 @@
 
 - name: Install Storage Prereqs
   package: name='{{ item }}' state=present
+  register: _pkg_success
+  until: _pkg_success|success
+  retries: '{{ pkg_retries }}'
+  delay: '{{ pkg_delay }}'
   with_items: '{{ _des_pkgs|default([]) }}'
 
 - name: Config Storage Driver
   include: '{{ docker_engine_storage_driver|lower }}.yml'
   when: docker_engine_storage_driver is defined
-

--- a/tasks/storage/main.yml
+++ b/tasks/storage/main.yml
@@ -13,10 +13,10 @@
 
 - name: Install Storage Prereqs
   package: name='{{ item }}' state=present
-  register: _pkg_success
-  until: _pkg_success|success
-  retries: '{{ pkg_retries }}'
-  delay: '{{ pkg_delay }}'
+  register: _external_dependency_success
+  until: _external_dependency_success|success
+  retries: '{{ external_dependency_retries }}'
+  delay: '{{ external_dependency_delay }}'
   with_items: '{{ _des_pkgs|default([]) }}'
 
 - name: Config Storage Driver

--- a/tests/cloud/cs-engine.yml
+++ b/tests/cloud/cs-engine.yml
@@ -2,16 +2,16 @@
 - name: docker
   hosts: all
   connection: local
-  gather_facts: True
+  gather_facts: true
   roles:
     - docker-engine
   tags:
-   - 'docker'
+    - 'docker'
   vars:
     docker_manage_py: true
-    docker_engine_commercial_support: True
+    docker_py_version: '1.10.6'
     docker_engine_version: '1.12.3'
-    docker_py_version: '1.9.0'
+    docker_engine_commercial_support: true
     docker_engine_env_vars:
       DOCKER_HOST: /var/run/docker.sock
       TLS_VERIFY: TRUE
@@ -21,10 +21,10 @@
         - '8.8.4.4'
     docker_images:
       - name: nginx
-        tag: '1.10.1-alpine'
+        tag: 'stable-alpine'
     docker_containers:
       - name: nginx
-        image: 'nginx:1.10.1-alpine'
+        image: 'nginx:stable-alpine'
     docker_networks:
       - name: testnet
         driver_options:

--- a/tests/cloud/latest.yml
+++ b/tests/cloud/latest.yml
@@ -7,13 +7,8 @@
     - docker-engine
   tags:
     - 'docker'
-    - 'docker:storage'
   vars:
     docker_manage_py: true
-    docker_py_version: '1.10.6'
-    docker_engine_version: '1.12.3'
-    docker_manage_engine_storage: true
-    docker_engine_storage_driver: aufs
     docker_engine_env_vars:
       DOCKER_HOST: /var/run/docker.sock
       TLS_VERIFY: TRUE

--- a/tests/cloud/os-engine.yml
+++ b/tests/cloud/os-engine.yml
@@ -2,13 +2,14 @@
 - name: docker
   hosts: all
   connection: local
-  gather_facts: True
-  tags:
-   - 'docker'
+  gather_facts: true
   roles:
     - docker-engine
+  tags:
+    - 'docker'
   vars:
     docker_manage_py: true
+    docker_py_version: '1.10.6'
     docker_engine_version: '1.12.3'
     docker_engine_env_vars:
       DOCKER_HOST: /var/run/docker.sock
@@ -19,10 +20,10 @@
         - '8.8.4.4'
     docker_images:
       - name: nginx
-        tag: '1.10.1-alpine'
+        tag: 'stable-alpine'
     docker_containers:
       - name: nginx
-        image: 'nginx:1.10.1-alpine'
+        image: 'nginx:stable-alpine'
     docker_networks:
       - name: testnet
         driver_options:

--- a/tests/cloud/py-pkg.yml
+++ b/tests/cloud/py-pkg.yml
@@ -2,13 +2,12 @@
 - name: docker
   hosts: all
   connection: local
-  gather_facts: True
-  tags:
-   - 'docker'
+  gather_facts: true
   roles:
     - docker-engine
+  tags:
+    - 'docker'
   vars:
-    docker_engine_commercial_support: false
     docker_manage_py: true
     docker_py_install: pkg
     docker_engine_version: '1.12.3'

--- a/tests/cloud/storage-btrfs.yml
+++ b/tests/cloud/storage-btrfs.yml
@@ -2,15 +2,15 @@
 - name: docker
   hosts: all
   connection: local
-  gather_facts: True
-  tags:
-   - 'docker'
-   - 'docker:storage'
+  gather_facts: true
   roles:
-   - docker-engine
+    - docker-engine
+  tags:
+    - 'docker'
+    - 'docker:storage'
   vars:
     docker_manage_py: true
-    docker_engine_commercial_support: False
+    docker_py_version: '1.10.6'
     docker_engine_version: '1.12.3'
     docker_manage_engine_storage: true
     docker_engine_storage_driver: btrfs
@@ -25,10 +25,10 @@
         - '8.8.4.4'
     docker_images:
       - name: nginx
-        tag: '1.10.1-alpine'
+        tag: 'stable-alpine'
     docker_containers:
       - name: nginx
-        image: 'nginx:1.10.1-alpine'
+        image: 'nginx:stable-alpine'
     docker_networks:
       - name: testnet
         driver_options:

--- a/tests/cloud/storage-devicemapper.yml
+++ b/tests/cloud/storage-devicemapper.yml
@@ -2,15 +2,15 @@
 - name: docker
   hosts: all
   connection: local
-  gather_facts: True
-  tags:
-   - 'docker'
-   - 'docker:storage'
+  gather_facts: true
   roles:
-   - docker-engine
+    - docker-engine
+  tags:
+    - 'docker'
+    - 'docker:storage'
   vars:
     docker_manage_py: true
-    docker_engine_commercial_support: False
+    docker_py_version: '1.10.6'
     docker_engine_version: '1.12.3'
     docker_manage_engine_storage: true
     docker_engine_storage_driver: devicemapper
@@ -25,10 +25,10 @@
         - '8.8.4.4'
     docker_images:
       - name: nginx
-        tag: '1.10.1-alpine'
+        tag: 'stable-alpine'
     docker_containers:
       - name: nginx
-        image: 'nginx:1.10.1-alpine'
+        image: 'nginx:stable-alpine'
     docker_networks:
       - name: testnet
         driver_options:

--- a/tests/cloud/storage-overlay.yml
+++ b/tests/cloud/storage-overlay.yml
@@ -2,15 +2,15 @@
 - name: docker
   hosts: all
   connection: local
-  gather_facts: True
-  tags:
-   - 'docker'
-   - 'docker:storage'
+  gather_facts: true
   roles:
    - docker-engine
+  tags:
+    - 'docker'
+    - 'docker:storage'
   vars:
     docker_manage_py: true
-    docker_engine_commercial_support: False
+    docker_py_version: '1.10.6'
     docker_engine_version: '1.12.3'
     docker_manage_engine_storage: true
     docker_engine_storage_driver: overlay
@@ -23,10 +23,10 @@
         - '8.8.4.4'
     docker_images:
       - name: nginx
-        tag: '1.10.1-alpine'
+        tag: 'stable-alpine'
     docker_containers:
       - name: nginx
-        image: 'nginx:1.10.1-alpine'
+        image: 'nginx:stable-alpine'
     docker_networks:
       - name: testnet
         driver_options:

--- a/tests/vagrant/cs-engine.yml
+++ b/tests/vagrant/cs-engine.yml
@@ -2,13 +2,14 @@
 - name: docker
   hosts: all
   connection: local
-  gather_facts: True
+  gather_facts: true
   roles:
     - docker-engine
   tags:
-   - 'docker'
+    - 'docker'
   vars:
     docker_manage_py: true
+    docker_py_version: '1.10.6'
     docker_engine_commercial_support: True
     docker_engine_version: '1.12.3'
     docker_engine_env_vars:
@@ -24,10 +25,10 @@
       - vagrant
     docker_images:
       - name: nginx
-        tag: '1.10.1-alpine'
+        tag: 'stable-alpine'
     docker_containers:
       - name: nginx
-        image: 'nginx:1.10.1-alpine'
+        image: 'nginx:stable-alpine'
     docker_networks:
       - name: testnet
         driver_options:

--- a/tests/vagrant/latest.yml
+++ b/tests/vagrant/latest.yml
@@ -7,13 +7,8 @@
     - docker-engine
   tags:
     - 'docker'
-    - 'docker:storage'
   vars:
     docker_manage_py: true
-    docker_py_version: '1.10.6'
-    docker_engine_version: '1.12.3'
-    docker_manage_engine_storage: true
-    docker_engine_storage_driver: aufs
     docker_engine_env_vars:
       DOCKER_HOST: /var/run/docker.sock
       TLS_VERIFY: TRUE
@@ -21,6 +16,10 @@
       dns:
         - '8.8.8.8'
         - '8.8.4.4'
+      bip:
+        - '10.255.12.1/24'
+    docker_engine_users:
+      - vagrant
     docker_images:
       - name: nginx
         tag: 'stable-alpine'

--- a/tests/vagrant/os-engine.yml
+++ b/tests/vagrant/os-engine.yml
@@ -2,13 +2,14 @@
 - name: docker
   hosts: all
   connection: local
-  gather_facts: True
-  tags:
-   - 'docker'
+  gather_facts: true
   roles:
     - docker-engine
+  tags:
+    - 'docker'
   vars:
     docker_manage_py: true
+    docker_py_version: '1.10.6'
     docker_engine_version: '1.12.3'
     docker_engine_env_vars:
       DOCKER_HOST: /var/run/docker.sock
@@ -23,10 +24,10 @@
       - vagrant
     docker_images:
       - name: nginx
-        tag: '1.10.1-alpine'
+        tag: 'stable-alpine'
     docker_containers:
       - name: nginx
-        image: 'nginx:1.10.1-alpine'
+        image: 'nginx:stable-alpine'
     docker_networks:
       - name: testnet
         driver_options:

--- a/tests/vagrant/py-pkg.yml
+++ b/tests/vagrant/py-pkg.yml
@@ -2,13 +2,12 @@
 - name: docker
   hosts: all
   connection: local
-  gather_facts: True
-  tags:
-   - 'docker'
+  gather_facts: true
   roles:
     - docker-engine
+  tags:
+    - 'docker'
   vars:
-    docker_engine_commercial_support: False
     docker_manage_py: true
     docker_py_install: pkg
     docker_engine_version: '1.12.3'

--- a/tests/vagrant/storage-aufs.yml
+++ b/tests/vagrant/storage-aufs.yml
@@ -2,16 +2,15 @@
 - name: docker
   hosts: all
   connection: local
-  gather_facts: True
-  tags:
-   - 'docker'
-   - 'docker:storage'
+  gather_facts: true
   roles:
    - docker-engine
+  tags:
+    - 'docker'
+    - 'docker:storage'
   vars:
     docker_manage_py: true
-    docker_py_version: '1.9.0'
-    docker_engine_commercial_support: False
+    docker_py_version: '1.10.6'
     docker_engine_version: '1.12.3'
     docker_manage_engine_storage: true
     docker_engine_storage_driver: aufs
@@ -28,10 +27,10 @@
       - vagrant
     docker_images:
       - name: nginx
-        tag: '1.10.1-alpine'
+        tag: 'stable-alpine'
     docker_containers:
       - name: nginx
-        image: 'nginx:1.10.1-alpine'
+        image: 'nginx:stable-alpine'
     docker_networks:
       - name: testnet
         driver_options:

--- a/tests/vagrant/storage-btrfs.yml
+++ b/tests/vagrant/storage-btrfs.yml
@@ -2,16 +2,15 @@
 - name: docker
   hosts: all
   connection: local
-  gather_facts: True
-  tags:
-   - 'docker'
-   - 'docker:storage'
+  gather_facts: true
   roles:
    - docker-engine
+  tags:
+    - 'docker'
+    - 'docker:storage'
   vars:
     docker_manage_py: true
-    docker_py_version: '1.9.0'
-    docker_engine_commercial_support: False
+    docker_py_version: '1.10.6'
     docker_engine_version: '1.12.3'
     docker_manage_engine_storage: true
     docker_engine_storage_driver: btrfs
@@ -30,10 +29,10 @@
       - vagrant
     docker_images:
       - name: nginx
-        tag: '1.10.1-alpine'
+        tag: 'stable-alpine'
     docker_containers:
       - name: nginx
-        image: 'nginx:1.10.1-alpine'
+        image: 'nginx:stable-alpine'
     docker_networks:
       - name: testnet
         driver_options:

--- a/tests/vagrant/storage-devicemapper.yml
+++ b/tests/vagrant/storage-devicemapper.yml
@@ -2,16 +2,15 @@
 - name: docker
   hosts: all
   connection: local
-  gather_facts: True
-  tags:
-   - 'docker'
-   - 'docker:storage'
+  gather_facts: true
   roles:
    - docker-engine
+  tags:
+    - 'docker'
+    - 'docker:storage'
   vars:
     docker_manage_py: true
-    docker_py_version: '1.9.0'
-    docker_engine_commercial_support: False
+    docker_py_version: '1.10.6'
     docker_engine_version: '1.12.3'
     docker_manage_engine_storage: true
     docker_engine_storage_driver: devicemapper
@@ -30,10 +29,10 @@
       - vagrant
     docker_images:
       - name: nginx
-        tag: '1.10.1-alpine'
+        tag: 'stable-alpine'
     docker_containers:
       - name: nginx
-        image: 'nginx:1.10.1-alpine'
+        image: 'nginx:stable-alpine'
     docker_networks:
       - name: testnet
         driver_options:

--- a/tests/vagrant/storage-overlay.yml
+++ b/tests/vagrant/storage-overlay.yml
@@ -2,16 +2,15 @@
 - name: docker
   hosts: all
   connection: local
-  gather_facts: True
-  tags:
-   - 'docker'
-   - 'docker:storage'
+  gather_facts: true
   roles:
    - docker-engine
+  tags:
+    - 'docker'
+    - 'docker:storage'
   vars:
     docker_manage_py: true
-    docker_py_version: '1.9.0'
-    docker_engine_commercial_support: False
+    docker_py_version: '1.10.6'
     docker_engine_version: '1.12.3'
     docker_manage_engine_storage: true
     docker_engine_storage_driver: overlay
@@ -28,10 +27,10 @@
       - vagrant
     docker_images:
       - name: nginx
-        tag: '1.10.1-alpine'
+        tag: 'stable-alpine'
     docker_containers:
       - name: nginx
-        image: 'nginx:1.10.1-alpine'
+        image: 'nginx:stable-alpine'
     docker_networks:
       - name: testnet
         driver_options:


### PR DESCRIPTION
This adds two additional variables that manage retry attempts for tasks that depend on an external source (repos, gpg keyservers, docker registry etc):

external_dependency_retries - number of attempted retries
external_dependency_delay - seconds between retry attempts

These were added to account for random issues when deploying and certain external tasks timing out failing the builds (frequently an issue with aws t2.micro instances)

